### PR TITLE
Update VouchersTab.tsx

### DIFF
--- a/frontend/src/components/tabs/VouchersTab.tsx
+++ b/frontend/src/components/tabs/VouchersTab.tsx
@@ -132,7 +132,7 @@ export default function VouchersTab() {
 
   const handlePrintClick = (mode: PrintMode) => {
     // Prepare the data for the URL
-    const vouchersParam = encodeURIComponent(JSON.stringify(vouchers));
+    const vouchersParam = encodeURIComponent(JSON.stringify(selectedVouchers));
     const printUrl = `/print?vouchers=${vouchersParam}&mode=${mode}`;
 
     router.replace(printUrl);


### PR DESCRIPTION
Small change which partially fixes HTTP-Error 431 ("Request Header Fields Too Large") when printing batches of vouchers. 
This PR solves the issue that when selecting vouchers, only the selected vouchers are being printed, and not all of them in the list

 (partial fix for [#25](https://github.com/etiennecollin/unifi-voucher-manager/issues/25) )